### PR TITLE
Do not swallow errors thrown in callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,9 @@ module.exports = function (stream, done) {
 
   if (typeof done === 'function') {
     deferred.then(function (arr) {
-      done(null, arr)
+      process.nextTick(function() {
+        done(null, arr)
+      })
     }, done)
   }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "devDependencies": {
     "bluebird": "^3.1.1",
     "istanbul": "0",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "trycatch": "^1.5.21"
   },
   "scripts": {
     "test": "mocha --reporter spec --bail",

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ var assert = require('assert')
 var stream = require('stream')
 var path = require('path')
 var fs = require('fs')
+var trycatch = require("trycatch")
 
 var toArray = require('..')
 
@@ -59,6 +60,27 @@ describe('Stream To Array', function () {
         assert.ok(Array.isArray(arr))
         assert.equal(arr.length, 0)
       })
+    })
+
+    it('should not swallow errors', function (done) {
+      var id = {}
+      trycatch(
+        function () {
+          toArray(emptyStream(), function (err, arr) {
+            if (err)
+              return done(err)
+
+            var err = new Error("foo")
+            err.id = id
+            throw err
+          })
+        },
+        function (err) {
+          assert(err);
+          assert.equal(err.id, id);
+          done();
+        }
+      )
     })
   })
 


### PR DESCRIPTION
I had an issue where a synchronous error thrown in the callback I passed to toArray was swallowed and never reported to me like I would expect. This happens because the callback executes in a promise.then() callback stack trace. The promise implementation catches the error and doesn't report it other than via the "unhandledRejection" event. I am not using promises in my application code so I don't have an "unhandledRejection" handler (and wasn't even aware of it). It took me a while to track down that an error was even being thrown before I tracked down where it was being swallowed.

This change uses process.nextTick to remove the callback from the promise.then call stack. I'm not sure if this is the best way to make sure the error gets reported. I'm not super familiar with promises but maybe it'd be better if an explicit error handler was registered on the promise and the error was re-thrown by that handler.

I also added a test using *trycatch* to make sure that the thrown error is reported up the stack as expected by a callback user.