### PR TITLE
Split 'end' and 'error' events

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function (stream, done) {
 
     stream.on('data', onData)
     stream.on('end', onEnd)
-    stream.on('error', onEnd)
+    stream.on('error', onError)
     stream.on('close', onClose)
 
     function onData(doc) {
@@ -29,8 +29,12 @@ module.exports = function (stream, done) {
     }
 
     function onEnd(err) {
-      if (err) reject(err)
-      else resolve(arr)
+      resolve(arr)
+      cleanup()
+    }
+
+    function onError(err) {
+      reject(err)
       cleanup()
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -89,6 +89,16 @@ describe('Stream To Array', function () {
         if (err) return done(err)
       })
     })
+
+    it('should handle stream errors', function (done) {
+      toArray(fs.createReadStream("madeupfile.jpg"))
+        .then(function () {
+          done(new Error("Promise should be rejected"))
+        })
+        .catch(function (err) {
+          done()
+        })
+    })
   })
 
   describe('as a method', function () {


### PR DESCRIPTION
I was trying to use `stream-to-array` with a stream that passed a non-error value to the `end` callback ([fast-csv](https://www.npmjs.com/package/fast-csv)). `stream-to-array` treated this as an error even though it wasn't one. This should fix the issue while still handling errors.